### PR TITLE
Fixed `mvnw` permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
 
 RUN dos2unix mvnw
 
+RUN chmod +x ./mvnw
 RUN ./mvnw dependency:go-offline
  
 COPY src ./src


### PR DESCRIPTION
Corrige el siguiente error al ejecutar un `docker build` en Linux:
```
=> [6/8] RUN dos2unix mvnw                                                                                        0.3s
 => ERROR [7/8] RUN ./mvnw dependency:go-offline                                                                   0.4s 
------                                                                                                                  
 > [7/8] RUN ./mvnw dependency:go-offline:                                                                              
0.389 /bin/sh: 1: ./mvnw: Permission denied                                                                             
------                                                                                                                  
Dockerfile:14
--------------------
  12 |     RUN dos2unix mvnw
  13 |     
  14 | >>> RUN ./mvnw dependency:go-offline
  15 |      
  16 |     COPY src ./src
--------------------
ERROR: failed to solve: process "/bin/sh -c ./mvnw dependency:go-offline" did not complete successfully: exit code: 126
```
